### PR TITLE
enforce UTF-8 encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,14 +27,12 @@ description = 'Gradle plugin to help analyzing projects with SonarQube'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
-compileJava.options.encoding = 'UTF-8'
-
-tasks.withType(JavaCompile) {
-    options.encoding = 'UTF-8'
+compileJava {
+  options.encoding = 'UTF-8'
 }
 
 javadoc {
-    options.encoding = 'UTF-8'
+  options.encoding = 'UTF-8'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,16 @@ description = 'Gradle plugin to help analyzing projects with SonarQube'
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
+compileJava.options.encoding = 'UTF-8'
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+javadoc {
+    options.encoding = 'UTF-8'
+}
+
 repositories {
   jcenter()
   mavenLocal()


### PR DESCRIPTION
Systems like Windows use cp1252 as default, so javadoc can not be generated, which failes the build.

This PR enforces UTF-8 for source files and javadoc generation