### PR TITLE
SONARGRADL-16 removing dependency to internal gradle class

### DIFF
--- a/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
@@ -19,6 +19,7 @@
  */
 package org.sonarqube.gradle;
 
+import aQute.bnd.build.Run;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
@@ -50,7 +51,6 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.listener.ActionBroadcast;
 import org.gradle.testing.jacoco.plugins.JacocoPlugin;
 import org.gradle.testing.jacoco.plugins.JacocoTaskExtension;
@@ -360,13 +360,29 @@ public class SonarQubePlugin implements Plugin<Project> {
 
   private static Collection<File> getLibraries(SourceSet main) {
     List<File> libraries = Lists.newLinkedList(Iterables.filter(main.getRuntimeClasspath(), IS_FILE));
-    File runtimeJar = Jvm.current().getRuntimeJar();
+    File runtimeJar = getRuntimeJar();
     if (runtimeJar != null) {
       libraries.add(runtimeJar);
     }
 
     return libraries;
   }
+
+  private static File getRuntimeJar() {
+    try{
+      final File javaBase =  new File(System.getProperty("java.home")).getCanonicalFile();
+      File runtimeJar = new File(javaBase, "lib/rt.jar");
+      if (runtimeJar.exists()) {
+        return runtimeJar;
+      }
+      runtimeJar = new File(javaBase, "jre/lib/rt.jar");
+      return runtimeJar.exists() ? runtimeJar : null;
+    } catch(IOException e){
+      throw new RuntimeException(e);
+    }
+
+  }
+
 
   private static void convertProperties(Map<String, Object> rawProperties, final String projectPrefix, final Map<String, Object> properties) {
     for (Map.Entry<String, Object> entry : rawProperties.entrySet()) {

--- a/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
+++ b/src/main/java/org/sonarqube/gradle/SonarQubePlugin.java
@@ -19,7 +19,6 @@
  */
 package org.sonarqube.gradle;
 
-import aQute.bnd.build.Run;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;


### PR DESCRIPTION
this PR fixed SONARGRADLE-16 it removes to class to the internal JVM class of gradle and backports the piece of code which was used in gradle 2.14.x to the plugin itself.

Since this internal class has changed with gradle 3.x the plugin works with gradle 3.0 too